### PR TITLE
Support exclude_dirs & exclude_files flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Flags:
     	also check and fix generated files
   -test_files
     	also check and fix test files
+  -exclude_dirs value
+    	exclude directories matching a pattern
+  -exclude_files value
+    	exclude files matching a pattern
 ```
 
 To get all recommendations on your project:
@@ -72,7 +76,7 @@ To automatically fix your project files, while ignoring test and generated files
 betteralign -apply ./...
 ```
 
-It is possible to include generated files and test files by enabling `generated_files` and/or `test_files` flags.
+It is possible to include generated files and test files by enabling `generated_files` and/or `test_files` flags, or exclude certain files or directories with the `exclude_dirs` and/or `exclude_files` flags.
 
 ## Star history
 

--- a/betteralign.go
+++ b/betteralign.go
@@ -37,6 +37,7 @@ import (
 	"go/token"
 	"go/types"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -92,12 +93,26 @@ var (
 	apply             bool
 	testFiles         bool
 	generatedFiles    bool
+	excludeFiles      StringArrayFlag
+	excludeDirs       StringArrayFlag
 	testSuffixes      = []string{"_test.go"}
 	generatedSuffixes = []string{"_generated.go", "_gen.go", ".gen.go", ".pb.go", ".pb.gw.go"}
 	ErrStatFile       = errors.New("unable to stat the file")
 	ErrNotRegularFile = errors.New("not a regular file, skipping")
 	ErrWriteFile      = errors.New("unable to write to file")
+	ErrPreFilterFiles = errors.New("failed to pre-filter files")
 )
+
+type StringArrayFlag []string
+
+func (f *StringArrayFlag) String() string {
+	return fmt.Sprintf("%v", *f)
+}
+
+func (f *StringArrayFlag) Set(value string) error {
+	*f = append(*f, strings.Split(value, ",")...)
+	return nil
+}
 
 var Analyzer = &analysis.Analyzer{
 	Name:     "betteralign",
@@ -106,10 +121,16 @@ var Analyzer = &analysis.Analyzer{
 	Run:      run,
 }
 
+func InitAnalyzer(analyzer *analysis.Analyzer) {
+	analyzer.Flags.BoolVar(&apply, "apply", false, "apply suggested fixes")
+	analyzer.Flags.BoolVar(&testFiles, "test_files", false, "also check and fix test files")
+	analyzer.Flags.BoolVar(&generatedFiles, "generated_files", false, "also check and fix generated files")
+	analyzer.Flags.Var(&excludeFiles, "exclude_files", "exclude files matching a pattern")
+	analyzer.Flags.Var(&excludeDirs, "exclude_dirs", "exclude directories matching a pattern")
+}
+
 func init() {
-	Analyzer.Flags.BoolVar(&apply, "apply", false, "apply suggested fixes")
-	Analyzer.Flags.BoolVar(&testFiles, "test_files", false, "also check and fix test files")
-	Analyzer.Flags.BoolVar(&generatedFiles, "generated_files", false, "also check and fix generated files")
+	InitAnalyzer(Analyzer)
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -138,6 +159,38 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 		if !generatedFiles && hasSuffixes(generatedFset, fn, generatedSuffixes) {
 			return
+		}
+
+		wd, err := os.Getwd()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v %s: %v", ErrPreFilterFiles, fn, err)
+			return
+		}
+		relfn, err := filepath.Rel(wd, fn)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v %s: %v", ErrPreFilterFiles, fn, err)
+			return
+		}
+		dir := filepath.Dir(relfn)
+		for _, excludeDir := range excludeDirs {
+			rel, err := filepath.Rel(excludeDir, dir)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%v %s: %v", ErrPreFilterFiles, fn, err)
+				return
+			}
+			if !strings.HasPrefix(rel, "..") {
+				return
+			}
+		}
+		for _, excludeFile := range excludeFiles {
+			match, err := filepath.Match(excludeFile, relfn)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%v %s: %v", ErrPreFilterFiles, fn, err)
+				return
+			}
+			if match {
+				return
+			}
 		}
 
 		if f, ok := node.(*ast.File); ok {

--- a/betteralign.go
+++ b/betteralign.go
@@ -161,35 +161,37 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			return
 		}
 
-		wd, err := os.Getwd()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%v %s: %v", ErrPreFilterFiles, fn, err)
-			return
-		}
-		relfn, err := filepath.Rel(wd, fn)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%v %s: %v", ErrPreFilterFiles, fn, err)
-			return
-		}
-		dir := filepath.Dir(relfn)
-		for _, excludeDir := range excludeDirs {
-			rel, err := filepath.Rel(excludeDir, dir)
+		if len(excludeDirs) > 0 || len(excludeFiles) > 0 {
+			wd, err := os.Getwd()
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "%v %s: %v", ErrPreFilterFiles, fn, err)
 				return
 			}
-			if !strings.HasPrefix(rel, "..") {
-				return
-			}
-		}
-		for _, excludeFile := range excludeFiles {
-			match, err := filepath.Match(excludeFile, relfn)
+			relfn, err := filepath.Rel(wd, fn)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "%v %s: %v", ErrPreFilterFiles, fn, err)
 				return
 			}
-			if match {
-				return
+			dir := filepath.Dir(relfn)
+			for _, excludeDir := range excludeDirs {
+				rel, err := filepath.Rel(excludeDir, dir)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "%v %s: %v", ErrPreFilterFiles, fn, err)
+					return
+				}
+				if !strings.HasPrefix(rel, "..") {
+					return
+				}
+			}
+			for _, excludeFile := range excludeFiles {
+				match, err := filepath.Match(excludeFile, relfn)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "%v %s: %v", ErrPreFilterFiles, fn, err)
+					return
+				}
+				if match {
+					return
+				}
 			}
 		}
 

--- a/testdata/src/exclude/a/a/a.go
+++ b/testdata/src/exclude/a/a/a.go
@@ -1,0 +1,6 @@
+package a
+
+type A struct {
+	a int
+	s string
+}

--- a/testdata/src/exclude/a/b/b.go
+++ b/testdata/src/exclude/a/b/b.go
@@ -1,0 +1,6 @@
+package b
+
+type B struct { // want "8 bytes saved: struct with 16 pointer bytes could be 8"
+	b int
+	s string
+}

--- a/testdata/src/exclude/a/b/c/c.go
+++ b/testdata/src/exclude/a/b/c/c.go
@@ -1,0 +1,6 @@
+package c
+
+type C struct { // want "8 bytes saved: struct with 16 pointer bytes could be 8"
+	c int
+	s string
+}

--- a/testdata/src/exclude/all/a/a.go
+++ b/testdata/src/exclude/all/a/a.go
@@ -1,0 +1,6 @@
+package a
+
+type A struct {
+	a int
+	s string
+}

--- a/testdata/src/exclude/all/b/b.go
+++ b/testdata/src/exclude/all/b/b.go
@@ -1,0 +1,6 @@
+package b
+
+type B struct {
+	b int
+	s string
+}

--- a/testdata/src/exclude/all/b/c/c.go
+++ b/testdata/src/exclude/all/b/c/c.go
@@ -1,0 +1,6 @@
+package c
+
+type C struct {
+	c int
+	s string
+}

--- a/testdata/src/exclude/b/a/a.go
+++ b/testdata/src/exclude/b/a/a.go
@@ -1,0 +1,6 @@
+package a
+
+type A struct { // want "8 bytes saved: struct with 16 pointer bytes could be 8"
+	a int
+	s string
+}

--- a/testdata/src/exclude/b/b/b.go
+++ b/testdata/src/exclude/b/b/b.go
@@ -1,0 +1,6 @@
+package b
+
+type B struct {
+	b int
+	s string
+}

--- a/testdata/src/exclude/b/b/c/c.go
+++ b/testdata/src/exclude/b/b/c/c.go
@@ -1,0 +1,6 @@
+package c
+
+type C struct { // want "8 bytes saved: struct with 16 pointer bytes could be 8"
+	c int
+	s string
+}

--- a/testdata/src/exclude/none/a/a.go
+++ b/testdata/src/exclude/none/a/a.go
@@ -1,0 +1,6 @@
+package a
+
+type A struct { // want "8 bytes saved: struct with 16 pointer bytes could be 8"
+	a int
+	s string
+}

--- a/testdata/src/exclude/none/b/b.go
+++ b/testdata/src/exclude/none/b/b.go
@@ -1,0 +1,6 @@
+package b
+
+type B struct { // want "8 bytes saved: struct with 16 pointer bytes could be 8"
+	b int
+	s string
+}

--- a/testdata/src/exclude/none/b/c/c.go
+++ b/testdata/src/exclude/none/b/c/c.go
@@ -1,0 +1,6 @@
+package c
+
+type C struct { // want "8 bytes saved: struct with 16 pointer bytes could be 8"
+	c int
+	s string
+}


### PR DESCRIPTION
Fixes #16 

This is a draft proposal. I'm yet unhappy with the tests and some of the code, I'll rewrite that before considering merging.  
What do you think of this approach @dkorunic?

- `exclude_dirs` requires a fully-qualified directory name, and excludes everything that's in it
- `exclude_files` supports golang's [glob syntax](https://pkg.go.dev/v.io/v23/glob), but not double-star syntax (using [bmatcuk/doublestar](https://github.com/bmatcuk/doublestar) could be interesting if we want that)

Usage examples:
```bash
betteralign -exclude_dirs "a/b" -apply ./a/...
betteralign -exclude_files "a/b/*" -exclude_dirs "c" ./...
```

My concerns at the moment:
- exports `InitAnalyzer` (only for test purposes)
- tests hard to read/`testdata` folder bloated
- code added to `betteralign.go` not super clean, will be reworked before merge